### PR TITLE
Revert changes made when trying to fix #8

### DIFF
--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -2,57 +2,30 @@
 
 
 <!DOCTYPE rdf:RDF [
-    <!ENTITY c4o "http://purl.org/spar/c4o#" >
     <!ENTITY terms "http://purl.org/dc/terms/" >
-    <!ENTITY cito "http://purl.org/spar/cito/" >
-    <!ENTITY foaf "http://xmlns.com/foaf/0.1/" >
-    <!ENTITY fabio "http://purl.org/spar/fabio/" >
     <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY bibo "http://purl.org/ontology/bibo/" >
     <!ENTITY obo "http://purl.obolibrary.org/obo/" >
     <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY vcard "http://www.w3.org/2006/vcard/ns#" >
-    <!ENTITY vivo "http://vivoweb.org/ontology/core#" >
     <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY event "http://purl.org/NET/c4dm/event.owl#" >
-    <!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
     <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY ocrer "http://purl.org/net/OCRe/research.owl#" >
-    <!ENTITY geo "http://aims.fao.org/aos/geopolitical.owl#" >
-    <!ENTITY ocresd "http://purl.org/net/OCRe/study_design.owl#" >
     <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY vitro-public "http://vitro.mannlib.cornell.edu/ns/vitro/public#" >
-    <!ENTITY rdfbones "http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones/1.0.0#" >
 ]>
 
 
-<rdf:RDF xmlns="http://www.w3.org/2002/07/owl#"
-     xml:base="http://www.w3.org/2002/07/owl"
-     xmlns:ocrer="http://purl.org/net/OCRe/research.owl#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:fabio="http://purl.org/spar/fabio/"
-     xmlns:rdfbones="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones/1.0.0#"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:ocresd="http://purl.org/net/OCRe/study_design.owl#"
-     xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
-     xmlns:cito="http://purl.org/spar/cito/"
-     xmlns:geo="http://aims.fao.org/aos/geopolitical.owl#"
-     xmlns:vitro-public="http://vitro.mannlib.cornell.edu/ns/vitro/public#"
+<rdf:RDF xmlns="http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones#"
+     xml:base="http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:terms="http://purl.org/dc/terms/"
-     xmlns:bibo="http://purl.org/ontology/bibo/"
-     xmlns:vivo="http://vivoweb.org/ontology/core#"
-     xmlns:event="http://purl.org/NET/c4dm/event.owl#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
-     xmlns:foaf="http://xmlns.com/foaf/0.1/"
-     xmlns:c4o="http://purl.org/spar/c4o#"
      xmlns:dc="http://purl.org/dc/elements/1.1/">
-    <Ontology rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones">
+    <owl:Ontology rdf:about="http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones">
         <rdfs:comment xml:lang="en">This ontology models procedures, data and results from research involving materials from skeletal collections.</rdfs:comment>
-        <versionIRI rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones/1.0.0"/>
-    </Ontology>
+        <owl:imports rdf:resource="http://vivoweb.org/ontology/core"/>
+        <owl:versionIRI rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones/0.1"/>
+    </owl:Ontology>
     
 
 
@@ -67,45 +40,15 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000112 -->
-
-    <AnnotationProperty rdf:about="&obo;IAO_0000112"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
-
-    <AnnotationProperty rdf:about="&obo;IAO_0000115"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
-
-    <AnnotationProperty rdf:about="&obo;IAO_0000119"/>
-    
-
-
     <!-- http://purl.org/dc/elements/1.1/description -->
 
-    <AnnotationProperty rdf:about="&dc;description"/>
-    
-
-
-    <!-- http://purl.org/dc/terms/description -->
-
-    <AnnotationProperty rdf:about="&terms;description"/>
+    <owl:AnnotationProperty rdf:about="&dc;description"/>
     
 
 
     <!-- http://purl.org/dc/terms/hasVersion -->
 
-    <AnnotationProperty rdf:about="&terms;hasVersion"/>
-    
-
-
-    <!-- http://www.w3.org/2004/02/skos/core#scopeNote -->
-
-    <AnnotationProperty rdf:about="&skos;scopeNote"/>
+    <owl:AnnotationProperty rdf:about="&terms;hasVersion"/>
     
 
 
@@ -120,32 +63,23 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0000136 -->
-
-    <ObjectProperty rdf:about="&obo;IAO_0000136"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/IAO_0000142 -->
 
-    <ObjectProperty rdf:about="&obo;IAO_0000142">
-        <obo:IAO_0000115>An information artifact IA mentions an entity E exactly when it has a component/part that denotes E.</obo:IAO_0000115>
-        <rdfs:range rdf:resource="&obo;BFO_0000001"/>
-        <rdfs:domain rdf:resource="&obo;IAO_0000030"/>
-        <rdfs:subPropertyOf rdf:resource="&obo;IAO_0000136"/>
-    </ObjectProperty>
+    <rdf:Description rdf:about="&obo;IAO_0000142"/>
     
 
 
     <!-- http://purl.org/dc/terms/contributor -->
 
-    <ObjectProperty rdf:about="&terms;contributor"/>
+    <owl:ObjectProperty rdf:about="&terms;contributor">
+        <rdfs:label>contributor</rdfs:label>
+    </owl:ObjectProperty>
     
 
 
     <!-- http://purl.org/dc/terms/creator -->
 
-    <ObjectProperty rdf:about="&terms;creator">
+    <owl:ObjectProperty rdf:about="&terms;creator">
         <rdfs:label xml:lang="en">Creator</rdfs:label>
         <rdfs:comment xml:lang="en">An entity primarily responsible for making the resource.</rdfs:comment>
         <terms:description xml:lang="en">Examples of a Creator include a person, an organization, or a service.</terms:description>
@@ -153,25 +87,29 @@
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/terms/"/>
         <rdfs:range rdf:resource="&terms;Agent"/>
         <rdfs:subPropertyOf rdf:resource="&terms;contributor"/>
-    </ObjectProperty>
+    </owl:ObjectProperty>
     
 
 
-    <!-- http://vivoweb.org/ontology/core#dateIssued -->
+    <!-- http://purl.org/ontology/bibo/performer -->
 
-    <ObjectProperty rdf:about="&vivo;dateIssued"/>
+    <rdf:Description rdf:about="http://purl.org/ontology/bibo/performer">
+        <rdfs:subPropertyOf rdf:resource="&terms;contributor"/>
+    </rdf:Description>
     
 
 
-    <!-- http://vivoweb.org/ontology/core#relates -->
+    <!-- http://purl.org/ontology/bibo/translator -->
 
-    <ObjectProperty rdf:about="&vivo;relates"/>
+    <rdf:Description rdf:about="http://purl.org/ontology/bibo/translator">
+        <rdfs:subPropertyOf rdf:resource="&terms;contributor"/>
+    </rdf:Description>
     
 
 
     <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#depicts -->
 
-    <ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#depicts">
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#depicts">
         <rdfs:label xml:lang="en">depicts</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">An information source depicts something when it renders a representation of it, using words, sounds, images, or other means.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">The property is mainly applicable to images and audiovisual media, as obo:IAO_0000142 (&apos;mentions&apos;) covers cases were a textual information source denotes an entity.</rdfs:comment>
@@ -179,25 +117,24 @@
         <rdfs:range rdf:resource="&obo;BFO_0000001"/>
         <rdfs:domain rdf:resource="&obo;IAO_0000030"/>
         <rdfs:subPropertyOf rdf:resource="&obo;IAO_0000136"/>
-    </ObjectProperty>
+    </owl:ObjectProperty>
     
 
 
     <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#hasTranscription -->
 
-    <ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#hasTranscription">
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#hasTranscription">
         <rdfs:label xml:lang="en">has transcription</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">Relates a document to transcriptions of this document.</obo:IAO_0000115>
-        <rdfs:domain rdf:resource="&bibo;Document"/>
+        <rdfs:domain rdf:resource="http://purl.org/ontology/bibo/Document"/>
         <rdfs:range rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription"/>
-        <rdfs:subPropertyOf rdf:resource="&owl;topObjectProperty"/>
-    </ObjectProperty>
+    </owl:ObjectProperty>
     
 
 
     <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isDepicted -->
 
-    <ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isDepicted">
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isDepicted">
         <rdfs:label xml:lang="en">is depicted in</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">Something is depicted by an information source when the information source renders a representation of it, using words, sounds, images, or other means.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">The property is mainly applicable to images and audiovisual media, as rdfBones:isMentioned covers cases were an entity is denoted by a textual information source.</rdfs:comment>
@@ -205,80 +142,33 @@
         <rdfs:domain rdf:resource="&obo;BFO_0000001"/>
         <rdfs:range rdf:resource="&obo;IAO_0000030"/>
         <rdfs:subPropertyOf rdf:resource="&obo;IAO_0000136"/>
-        <inverseOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#depicts"/>
-    </ObjectProperty>
+        <owl:inverseOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#depicts"/>
+    </owl:ObjectProperty>
     
 
 
     <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isMentioned -->
 
-    <ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isMentioned">
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isMentioned">
         <rdfs:label xml:lang="en">is mentioned in</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">An entity E is mentioned by an information artifact IA exactly when IA has a component/part that denotes E.</obo:IAO_0000115>
         <rdfs:domain rdf:resource="&obo;BFO_0000001"/>
         <rdfs:range rdf:resource="&obo;IAO_0000030"/>
         <rdfs:subPropertyOf rdf:resource="&obo;IAO_0000136"/>
-        <inverseOf rdf:resource="&obo;IAO_0000142"/>
-    </ObjectProperty>
+        <owl:inverseOf rdf:resource="&obo;IAO_0000142"/>
+    </owl:ObjectProperty>
     
 
 
     <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#transcriptionOf -->
 
-    <ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#transcriptionOf">
+    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#transcriptionOf">
         <rdfs:label xml:lang="en">transcription of</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">Relates a transcription to the original document.</obo:IAO_0000115>
-        <rdfs:range rdf:resource="&bibo;Document"/>
+        <rdfs:range rdf:resource="http://purl.org/ontology/bibo/Document"/>
         <rdfs:domain rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription"/>
-        <inverseOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#hasTranscription"/>
-    </ObjectProperty>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Data properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://purl.org/ontology/bibo/chapter -->
-
-    <DatatypeProperty rdf:about="&bibo;chapter"/>
-    
-
-
-    <!-- http://purl.org/ontology/bibo/pageEnd -->
-
-    <DatatypeProperty rdf:about="&bibo;pageEnd"/>
-    
-
-
-    <!-- http://purl.org/ontology/bibo/pageStart -->
-
-    <DatatypeProperty rdf:about="&bibo;pageStart"/>
-    
-
-
-    <!-- http://purl.org/ontology/bibo/section -->
-
-    <DatatypeProperty rdf:about="&bibo;section"/>
-    
-
-
-    <!-- http://purl.org/ontology/bibo/volume -->
-
-    <DatatypeProperty rdf:about="&bibo;volume"/>
-    
-
-
-    <!-- http://www.w3.org/2006/vcard/ns#note -->
-
-    <DatatypeProperty rdf:about="&vcard;note"/>
+        <owl:inverseOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#hasTranscription"/>
+    </owl:ObjectProperty>
     
 
 
@@ -293,149 +183,105 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/BFO_0000001 -->
-
-    <Class rdf:about="&obo;BFO_0000001"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/IAO_0000030 -->
-
-    <Class rdf:about="&obo;IAO_0000030"/>
-    
-
-
     <!-- http://purl.org/dc/terms/Agent -->
 
-    <Class rdf:about="&terms;Agent"/>
-    
-
-
-    <!-- http://purl.org/ontology/bibo/Document -->
-
-    <Class rdf:about="&bibo;Document"/>
-    
-
-
-    <!-- http://vivoweb.org/ontology/core#DateTimeValue -->
-
-    <Class rdf:about="&vivo;DateTimeValue"/>
+    <owl:Class rdf:about="&terms;Agent"/>
     
 
 
     <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchNote -->
 
-    <Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchNote">
+    <owl:Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchNote">
         <rdfs:label xml:lang="en">Research Note</rdfs:label>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&vivo;relates"/>
-                <onClass rdf:resource="&obo;BFO_0000001"/>
-                <minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</minQualifiedCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&terms;creator"/>
+                <owl:onClass rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&terms;creator"/>
-                <onClass rdf:resource="&foaf;Person"/>
-                <qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</qualifiedCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://vivoweb.org/ontology/core#dateIssued"/>
+                <owl:onClass rdf:resource="http://vivoweb.org/ontology/core#DateTimeValue"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&vivo;dateIssued"/>
-                <onClass rdf:resource="&vivo;DateTimeValue"/>
-                <qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</qualifiedCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://vivoweb.org/ontology/core#relates"/>
+                <owl:onClass rdf:resource="&obo;BFO_0000001"/>
+                <owl:minQualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:minQualifiedCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&vcard;note"/>
-                <qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</qualifiedCardinality>
-                <onDataRange rdf:resource="&xsd;string"/>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://www.w3.org/2006/vcard/ns#note"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="&xsd;string"/>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115 xml:lang="en">A piece of textual user input, containing additional information on one or several resources. It can be used to relate resources with each other.</obo:IAO_0000115>
-    </Class>
+    </owl:Class>
     
 
 
     <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchReference -->
 
-    <Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchReference">
+    <owl:Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchReference">
         <rdfs:label xml:lang="en">Research Reference</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchNote"/>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&bibo;pageEnd"/>
-                <maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</maxCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://vivoweb.org/ontology/core#relates"/>
+                <owl:onClass rdf:resource="&obo;IAO_0000030"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&bibo;section"/>
-                <maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</maxCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/section"/>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&bibo;volume"/>
-                <maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</maxCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/pageStart"/>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&bibo;pageStart"/>
-                <maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</maxCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/pageEnd"/>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&vivo;relates"/>
-                <onClass rdf:resource="&obo;IAO_0000030"/>
-                <qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</qualifiedCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/chapter"/>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="&bibo;chapter"/>
-                <maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</maxCardinality>
-            </Restriction>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/volume"/>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115 xml:lang="en">A piece of textual user input, creating a relationship between one or several entities and an information content entity or part of it.</obo:IAO_0000115>
-    </Class>
+    </owl:Class>
     
 
 
     <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription -->
 
-    <Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription">
+    <owl:Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription">
         <rdfs:label>Transcription</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&bibo;Document"/>
+        <rdfs:subClassOf rdf:resource="http://purl.org/ontology/bibo/Document"/>
         <obo:IAO_0000112 rdf:datatype="&xsd;string">&quot;Transcription turns handwritten and typed documents into searchable and machine-readable resources.&quot;
 (https://transcription.si.edu/about; last accessed on 13 October 2015)</obo:IAO_0000112>
         <dc:description rdf:datatype="&xsd;string">The result of rendering a handwritten or recorded work in digital writing.</dc:description>
-    </Class>
-    
-
-
-    <!-- http://xmlns.com/foaf/0.1/Person -->
-
-    <Class rdf:about="&foaf;Person"/>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotations
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    <rdf:Description rdf:about="&vivo;College">
-        <skos:scopeNote xml:lang="en">Use this class for academic organisations that are not universities. The exact application might vary among local educational systems. Colleges are typically focussed on certain areas of research and provide a limited range of degrees.</skos:scopeNote>
-    </rdf:Description>
+    </owl:Class>
 </rdf:RDF>
 
 


### PR DESCRIPTION
When trying to fix #8, direct import of the VIVO public ontology was dropped because it was suspected to prevent the ontology to be recognised by VIVO. Later it was found out that the change was irrelevant but I forgot to revert it.