### PR TITLE
CRIDs

### DIFF
--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -25,7 +25,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:dc="http://purl.org/dc/elements/1.1/">
-    <owl:Ontology rdf:about="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones">
+    <owl:Ontology rdf:about="http://w3id.org/rdfbones/core">
         <rdfs:comment xml:lang="en">Find detailed information at http://w3id.org/rdfbones/.</rdfs:comment>
         <rdfs:comment xml:lang="en">This ontology is based on version 1.6 of the VIVO ISF ontology.</rdfs:comment>
         <terms:description xml:lang="en">This ontology models procedures, data and results from research involving materials from skeletal collections.</terms:description>
@@ -187,31 +187,9 @@
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones#hasPhysicalRepresentation -->
+    <!-- http://w3id.org/rdfbones/core#depicts -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones#hasPhysicalRepresentation">
-        <rdfs:label xml:lang="en">has physical representation</rdfs:label>
-        <obo:IAO_0000115 xml:lang="en">Specifies for a specific material object the existence of an artefact that was specifically manufactured to resemble this material object.</obo:IAO_0000115>
-        <rdfs:domain rdf:resource="&obo;BFO_0000040"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones#physicalRepresentation -->
-
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones#physicalRepresentation">
-        <rdfs:label xml:lang="en">is physical representation of</rdfs:label>
-        <skos:example xml:lang="en">A plaster cast from a Homo erectus mandible is a physical representation of the mandible itself.</skos:example>
-        <obo:IAO_0000115 xml:lang="en">Expresses that an artefact has been specifically manufactured in order to resemble a specific material object.</obo:IAO_0000115>
-        <rdfs:range rdf:resource="&obo;BFO_0000040"/>
-        <owl:inverseOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones#hasPhysicalRepresentation"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#depicts -->
-
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#depicts">
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core#depicts">
         <rdfs:label xml:lang="en">depicts</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">An information source depicts something when it renders a representation of it, using words, sounds, images, or other means.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">The property is mainly applicable to images and audiovisual media, as obo:IAO_0000142 (&apos;mentions&apos;) covers cases were a textual information source denotes an entity.</rdfs:comment>
@@ -223,20 +201,30 @@
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#hasTranscription -->
+    <!-- http://w3id.org/rdfbones/core#hasPhysicalRepresentation -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#hasTranscription">
-        <rdfs:label xml:lang="en">has transcription</rdfs:label>
-        <obo:IAO_0000115 xml:lang="en">Relates a document to transcriptions of this document.</obo:IAO_0000115>
-        <rdfs:domain rdf:resource="http://purl.org/ontology/bibo/Document"/>
-        <rdfs:range rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription"/>
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core#hasPhysicalRepresentation">
+        <rdfs:label xml:lang="en">has physical representation</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">Specifies for a specific material object the existence of an artefact that was specifically manufactured to resemble this material object.</obo:IAO_0000115>
+        <rdfs:domain rdf:resource="&obo;BFO_0000040"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isDepicted -->
+    <!-- http://w3id.org/rdfbones/core#hasTranscription -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isDepicted">
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core#hasTranscription">
+        <rdfs:label xml:lang="en">has transcription</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">Relates a document to transcriptions of this document.</obo:IAO_0000115>
+        <rdfs:domain rdf:resource="http://purl.org/ontology/bibo/Document"/>
+        <rdfs:range rdf:resource="http://w3id.org/rdfbones/core#Transcription"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#isDepicted -->
+
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core#isDepicted">
         <rdfs:label xml:lang="en">is depicted in</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">Something is depicted by an information source when the information source renders a representation of it, using words, sounds, images, or other means.</obo:IAO_0000115>
         <rdfs:comment xml:lang="en">The property is mainly applicable to images and audiovisual media, as rdfBones:isMentioned covers cases were an entity is denoted by a textual information source.</rdfs:comment>
@@ -244,14 +232,14 @@
         <rdfs:domain rdf:resource="&obo;BFO_0000001"/>
         <rdfs:range rdf:resource="&obo;IAO_0000030"/>
         <rdfs:subPropertyOf rdf:resource="&obo;IAO_0000136"/>
-        <owl:inverseOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#depicts"/>
+        <owl:inverseOf rdf:resource="http://w3id.org/rdfbones/core#depicts"/>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isMentioned -->
+    <!-- http://w3id.org/rdfbones/core#isMentioned -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#isMentioned">
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core#isMentioned">
         <rdfs:label xml:lang="en">is mentioned in</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">An entity E is mentioned by an information artifact IA exactly when IA has a component/part that denotes E.</obo:IAO_0000115>
         <rdfs:domain rdf:resource="&obo;BFO_0000001"/>
@@ -262,14 +250,26 @@
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#transcriptionOf -->
+    <!-- http://w3id.org/rdfbones/core#physicalRepresentation -->
 
-    <owl:ObjectProperty rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#transcriptionOf">
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core#physicalRepresentation">
+        <rdfs:label xml:lang="en">is physical representation of</rdfs:label>
+        <skos:example xml:lang="en">A plaster cast from a Homo erectus mandible is a physical representation of the mandible itself.</skos:example>
+        <obo:IAO_0000115 xml:lang="en">Expresses that an artefact has been specifically manufactured in order to resemble a specific material object.</obo:IAO_0000115>
+        <rdfs:range rdf:resource="&obo;BFO_0000040"/>
+        <owl:inverseOf rdf:resource="http://w3id.org/rdfbones/core#hasPhysicalRepresentation"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#transcriptionOf -->
+
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core#transcriptionOf">
         <rdfs:label xml:lang="en">transcription of</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">Relates a transcription to the original document.</obo:IAO_0000115>
         <rdfs:range rdf:resource="http://purl.org/ontology/bibo/Document"/>
-        <rdfs:domain rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription"/>
-        <owl:inverseOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#hasTranscription"/>
+        <rdfs:domain rdf:resource="http://w3id.org/rdfbones/core#Transcription"/>
+        <owl:inverseOf rdf:resource="http://w3id.org/rdfbones/core#hasTranscription"/>
     </owl:ObjectProperty>
     
 
@@ -300,7 +300,7 @@
     <!-- http://purl.obolibrary.org/obo/FMA_61775 -->
 
     <rdf:Description rdf:about="&obo;FMA_61775">
-        <owl:equivalentClass rdf:resource="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#PhysicalAnatomicalEntity"/>
+        <owl:equivalentClass rdf:resource="http://w3id.org/rdfbones/core#PhysicalAnatomicalEntity"/>
     </rdf:Description>
     
 
@@ -308,7 +308,7 @@
     <!-- http://purl.obolibrary.org/obo/FMA_62955 -->
 
     <rdf:Description rdf:about="&obo;FMA_62955">
-        <owl:equivalentClass rdf:resource="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#AnatomicalEntity"/>
+        <owl:equivalentClass rdf:resource="http://w3id.org/rdfbones/core#AnatomicalEntity"/>
     </rdf:Description>
     
 
@@ -316,7 +316,7 @@
     <!-- http://purl.obolibrary.org/obo/FMA_67115 -->
 
     <rdf:Description rdf:about="&obo;FMA_67115">
-        <owl:equivalentClass rdf:resource="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#NonPhysicalAnatomicalEntity"/>
+        <owl:equivalentClass rdf:resource="http://w3id.org/rdfbones/core#NonPhysicalAnatomicalEntity"/>
     </rdf:Description>
     
 
@@ -330,59 +330,70 @@
     <!-- http://purl.org/NET/cidoc-crm/core#E24_Physical_Man-Made_Thing -->
 
     <rdf:Description rdf:about="http://purl.org/NET/cidoc-crm/core#E24_Physical_Man-Made_Thing">
-        <owl:equivalentClass rdf:resource="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#PhysicalManMadeThing"/>
+        <owl:equivalentClass rdf:resource="http://w3id.org/rdfbones/core#PhysicalManMadeThing"/>
     </rdf:Description>
     
 
 
-    <!-- http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#AnatomicalEntity -->
+    <!-- http://w3id.org/rdfbones/core#AnatomicalEntity -->
 
-    <owl:Class rdf:about="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#AnatomicalEntity">
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#AnatomicalEntity">
         <rdfs:subClassOf rdf:resource="&obo;BFO_0000001"/>
         <rdfs:comment xml:lang="en">The class was introduced to integrate concepts from the Foundational Model of Anatomy (FMA) into the RDFBones ontology (cf the &apos;Equivalent To&apos; axiom).</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#NonPhysicalAnatomicalEntity -->
+    <!-- http://w3id.org/rdfbones/core#HumanRemainsIdentifier -->
 
-    <owl:Class rdf:about="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#NonPhysicalAnatomicalEntity">
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#HumanRemainsIdentifier">
+        <rdfs:label xml:lang="en">Human skeletal remains identifier</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
+        <obo:IAO_0000115 xml:lang="en">A CRID symbol that identifies a batch of human remains.</obo:IAO_0000115>
+        <obo:IAO_0000112 xml:lang="en">Skeletal remains from a Neolithic grave that are stored under the same signature (CRID symbol) in a museum collection.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#NonPhysicalAnatomicalEntity -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#NonPhysicalAnatomicalEntity">
         <rdfs:subClassOf rdf:resource="&obo;BFO_0000141"/>
         <rdfs:comment xml:lang="en">The class was introduced to integrate concepts from the Foundational Model of Anatomy (FMA) into the RDFBones ontology (cf the &apos;Equivalent To&apos; axiom).</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#PhysicalAnatomicalEntity -->
+    <!-- http://w3id.org/rdfbones/core#PhysicalAnatomicalEntity -->
 
-    <owl:Class rdf:about="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#PhysicalAnatomicalEntity">
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#PhysicalAnatomicalEntity">
         <rdfs:subClassOf rdf:resource="&obo;BFO_0000040"/>
         <rdfs:comment xml:lang="en">The class was introduced to integrate concepts from the Foundational Model of Anatomy (FMA) into the RDFBones ontology (cf the &apos;Equivalent To&apos; axiom).</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#PhysicalManMadeThing -->
+    <!-- http://w3id.org/rdfbones/core#PhysicalManMadeThing -->
 
-    <owl:Class rdf:about="http://w3id.org/rdfbones/ontology_resources/latest/RDFBones#PhysicalManMadeThing">
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#PhysicalManMadeThing">
         <rdfs:subClassOf rdf:resource="&obo;BFO_0000040"/>
         <rdfs:comment xml:lang="en">The class was introduced to integrate concepts from the CIDOC CRM into the RDFBones ontology (cf the &apos;Equivalent To&apos; axiom).</rdfs:comment>
     </owl:Class>
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones#Replica -->
+    <!-- http://w3id.org/rdfbones/core#Replica -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/10/rdfBones#Replica">
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#Replica">
         <rdfs:label xml:lang="en">Replica</rdfs:label>
         <obo:IAO_0000115 xml:lang="en">An exact copy of another material entity. The replica can be made of different materials and at a different scale than the original.</obo:IAO_0000115>
     </owl:Class>
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchNote -->
+    <!-- http://w3id.org/rdfbones/core#ResearchNote -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchNote">
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#ResearchNote">
         <rdfs:label xml:lang="en">Research Note</rdfs:label>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -396,20 +407,20 @@
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchReference -->
+    <!-- http://w3id.org/rdfbones/core#ResearchReference -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchReference">
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#ResearchReference">
         <rdfs:label xml:lang="en">Research Reference</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#ResearchNote"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#ResearchNote"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/chapter"/>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/pageStart"/>
                 <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/pageStart"/>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/chapter"/>
                 <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -436,9 +447,9 @@
     
 
 
-    <!-- http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription -->
+    <!-- http://w3id.org/rdfbones/core#Transcription -->
 
-    <owl:Class rdf:about="http://www.semanticweb.org/engel/ontologies/2015/3/rdfBones#Transcription">
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#Transcription">
         <rdfs:label>Transcription</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.org/ontology/bibo/Document"/>
         <obo:IAO_0000112 rdf:datatype="&xsd;string">&quot;Transcription turns handwritten and typed documents into searchable and machine-readable resources.&quot;

--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -344,13 +344,93 @@
     
 
 
+    <!-- http://w3id.org/rdfbones/core#ArtefactIdentifier -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#ArtefactIdentifier">
+        <rdfs:label xml:lang="en">Artefact Identifier</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.org/NET/cidoc-crm/core#E22_Man-Made_Object"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115 xml:lang="en">A CRID symbol for identifying man-made objects.</obo:IAO_0000115>
+        <obo:IAO_0000112 xml:lang="en">A set of flint arrows recovered from a mesolithic site that are stored under the same signature (artefact identifier) in a museum collection.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#DocumentIdentifier -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#DocumentIdentifier">
+        <rdfs:label xml:lang="en">Document identifier</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://purl.org/ontology/bibo/Document"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115 xml:lang="en">A CRID symbol for identifying documents.</obo:IAO_0000115>
+        <obo:IAO_0000112 xml:lang="en">The written correspondence of a 19th century collector is stored under the same signature (document identifier) in a university archive.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
     <!-- http://w3id.org/rdfbones/core#HumanRemainsIdentifier -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#HumanRemainsIdentifier">
-        <rdfs:label xml:lang="en">Human skeletal remains identifier</rdfs:label>
+        <rdfs:label xml:lang="en">Human remains identifier</rdfs:label>
         <rdfs:subClassOf rdf:resource="&obo;IAO_0000577"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="&obo;FMA_67165"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <obo:IAO_0000115 xml:lang="en">A CRID symbol that identifies a batch of human remains.</obo:IAO_0000115>
-        <obo:IAO_0000112 xml:lang="en">Skeletal remains from a Neolithic grave that are stored under the same signature (CRID symbol) in a museum collection.</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">A South-american mummy that is kept under a specific signature (Human remains identifier) in a university collection.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#HumanSkeletalMaterialIdentifier -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#HumanSkeletalMaterialIdentifier">
+        <rdfs:label xml:lang="en">Human skeletal material identifier</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#HumanRemainsIdentifier"/>
+        <obo:IAO_0000115 xml:lang="en">A CRID symbol for identifying batches of human skeletal material.</obo:IAO_0000115>
+        <obo:IAO_0000112 xml:lang="en">Bones from a Neolithic grave that are stored under the same signature (Human skeletal remains identifier) in a museum collection.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#HumanSkeletalReplicaIdentifier -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#HumanSkeletalReplicaIdentifier">
+        <rdfs:label xml:lang="en">Human skeletal replica identifier</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#ArtefactIdentifier"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="&obo;IAO_0000136"/>
+                <owl:someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Replica"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115 xml:lang="en">A CRID symbol for identifying replica of specific human sekeltal elements.</obo:IAO_0000115>
+        <obo:IAO_0000112 xml:lang="en">Casts of the bones that constitute the skeleton AL 288-1 (aka Lucy) that are stored under the same signature (human skeletal replica identifier) in a university study collection.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#HumanSkeletonIdentifier -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#HumanSkeletonIdentifier">
+        <rdfs:label xml:lang="en">Human skeleton identifier</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&obo;OBI_0001141"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#HumanSkeletalMaterialIdentifier"/>
+        <obo:IAO_0000115 xml:lang="en">A CRID symbol for identifying individual human skeletons.</obo:IAO_0000115>
+        <obo:IAO_0000112 xml:lang="en">Human bones that are found to belong to the same skeleton listed under a sequence number (Human skeleton identifier) for an anthropological study.</obo:IAO_0000112>
     </owl:Class>
     
 
@@ -382,10 +462,42 @@
     
 
 
+    <!-- http://w3id.org/rdfbones/core#PrimaryRegistry -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#PrimaryRegistry">
+        <rdfs:label xml:lang="en">Primary registry</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#Relationship"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://vivoweb.org/ontology/core#dateTimeInterval"/>
+                <owl:allValuesFrom rdf:resource="http://vivoweb.org/ontology/core#DateTimeInterval"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://vivoweb.org/ontology/core#relates"/>
+                <owl:onClass rdf:resource="http://purl.org/NET/cidoc-crm/core#E78_Collection"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://vivoweb.org/ontology/core#relates"/>
+                <owl:onClass rdf:resource="&obo;IAO_0000579"/>
+                <owl:qualifiedCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:qualifiedCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000115 xml:lang="en">A dual relationship between a collection and a centrally registered identifier (CRID) registry that - for a defined period of time - serves as the primary collection catalogue/inventory. All other CRID registries have to reference a primary registry in order to avoid duplicate instances representing the same object.</obo:IAO_0000115>
+        <obo:IAO_0000112 xml:lang="en">The inventory of the Freiburg University Archive is the primary registry of the Alexander Ecker Collection.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
     <!-- http://w3id.org/rdfbones/core#Replica -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Replica">
         <rdfs:label xml:lang="en">Replica</rdfs:label>
+        <rdfs:subClassOf rdf:resource="http://purl.org/NET/cidoc-crm/core#E22_Man-Made_Object"/>
         <obo:IAO_0000115 xml:lang="en">An exact copy of another material entity. The replica can be made of different materials and at a different scale than the original.</obo:IAO_0000115>
     </owl:Class>
     
@@ -420,7 +532,13 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/chapter"/>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/section"/>
+                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/volume"/>
                 <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -432,13 +550,7 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/section"/>
-                <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/volume"/>
+                <owl:onProperty rdf:resource="http://purl.org/ontology/bibo/chapter"/>
                 <owl:maxCardinality rdf:datatype="&xsd;nonNegativeInteger">1</owl:maxCardinality>
             </owl:Restriction>
         </rdfs:subClassOf>


### PR DESCRIPTION
Implements the organisation of materials with centrally registered identifier systems and creates the option to define primary registries.

@zarquon42b  and @kdaveed The implementation of primary registers deviates from our decision from the meeting on 1 December 2015. Sorry for this. As the VIVO design principles request to model time periods wherever possible, the definition of primary registers had to be realised as a relationship. This also offers the option to change primary registers without risking duplicate instances. The new primary register can be developed from the old by setting 'sameAs' relationships.

And there is yet another apology. I had to change the ontology IRI again in order to indicate that this is the core ontology. I think this is necessary, as we will want to publish some extensions along with the core ontology in order to offer some functionality. These will need their own distinct IRIs. I know that this is an unpopular decision and runs against my promises during the meeting on 15 December 2015 but it is better do fiddle with these things earlier than having to work around early mistakes later.