### PR TITLE
Skeletal inventories

### DIFF
--- a/CIDOC-CRM-RDFBonesSubset.owl
+++ b/CIDOC-CRM-RDFBonesSubset.owl
@@ -1,25 +1,15 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY vitro "http://vitro.mannlib.cornell.edu/ns/vitro/0.7#" >
-]>
-
-
 <rdf:RDF xmlns="http://www.cidoc-crm.org/cidoc-crm/"
      xml:base="http://www.cidoc-crm.org/cidoc-crm/"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:vitro="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#">
     <owl:Ontology rdf:about="http://www.cidoc-crm.org/cidoc-crm/">
         <rdfs:label xml:lang="en-us">CIDOC Conceptual Reference Model</rdfs:label>
-        <vitro:ontologyPrefixAnnot rdf:datatype="&rdfs;Literal">cidoc-crm</vitro:ontologyPrefixAnnot>
+        <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">cidoc-crm</vitro:ontologyPrefixAnnot>
     </owl:Ontology>
     
 
@@ -37,13 +27,13 @@
 
     <!-- http://vitro.mannlib.cornell.edu/ns/vitro/0.7#descriptionAnnot -->
 
-    <owl:AnnotationProperty rdf:about="&vitro;descriptionAnnot"/>
+    <owl:AnnotationProperty rdf:about="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#descriptionAnnot"/>
     
 
 
     <!-- http://vitro.mannlib.cornell.edu/ns/vitro/0.7#ontologyPrefixAnnot -->
 
-    <owl:AnnotationProperty rdf:about="&vitro;ontologyPrefixAnnot"/>
+    <owl:AnnotationProperty rdf:about="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#ontologyPrefixAnnot"/>
     
 
 
@@ -61,16 +51,11 @@
     <!-- http://www.cidoc-crm.org/cidoc-crm/E22_Man-Made_Object -->
 
     <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E22_Man-Made_Object">
-        <rdfs:label xml:lang="de">Künstlicher Gegenstand</rdfs:label>
-        <rdfs:label xml:lang="el">Ανθρωπογενές Αντικείμενο</rdfs:label>
-        <rdfs:label xml:lang="en">Man-Made Object</rdfs:label>
-        <rdfs:label xml:lang="fr">Objet fabriqué</rdfs:label>
-        <rdfs:label xml:lang="pt">Objeto Fabricado</rdfs:label>
-        <rdfs:label xml:lang="ru">Рукотворный Объект</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E24_Physical_Man-Made_Thing"/>
         <vitro:descriptionAnnot xml:lang="en">This class comprises physical objects purposely created by human activity.
 No assumptions are made as to the extent of modification required to justify regarding an object as man-made. For example, an inscribed piece of rock or a preserved butterfly are both regarded as instances of E22 Man-Made Object.
 </vitro:descriptionAnnot>
+        <rdfs:label xml:lang="en">Man-Made Object</rdfs:label>
     </owl:Class>
     
 
@@ -78,16 +63,11 @@ No assumptions are made as to the extent of modification required to justify reg
     <!-- http://www.cidoc-crm.org/cidoc-crm/E24_Physical_Man-Made_Thing -->
 
     <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E24_Physical_Man-Made_Thing">
-        <rdfs:label xml:lang="de">Hergestelltes</rdfs:label>
-        <rdfs:label xml:lang="el">Ανθρωπογενές Υλικό Πράγμα</rdfs:label>
-        <rdfs:label xml:lang="en">Physical Man-Made Thing</rdfs:label>
-        <rdfs:label xml:lang="fr">Chose matérielle fabriquée</rdfs:label>
-        <rdfs:label xml:lang="pt">Coisa Material Fabricada</rdfs:label>
-        <rdfs:label xml:lang="ru">Физическая Рукотворная Вещь</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E71_Man-Made_Thing"/>
         <vitro:descriptionAnnot xml:lang="en">This class comprises all persistent physical items that are purposely created by human activity.
 This class comprises man-made objects, such as a swords, and man-made features, such as rock art. No assumptions are made as to the extent of modification required to justify regarding an object as man-made. For example, a “cup and ring” carving on bedrock is regarded as instance of E24 Physical Man-Made Thing. 
 </vitro:descriptionAnnot>
+        <rdfs:label xml:lang="en">Physical Man-Made Thing</rdfs:label>
     </owl:Class>
     
 
@@ -95,15 +75,10 @@ This class comprises man-made objects, such as a swords, and man-made features, 
     <!-- http://www.cidoc-crm.org/cidoc-crm/E71_Man-Made_Thing -->
 
     <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E71_Man-Made_Thing">
-        <rdfs:label xml:lang="de">Künstliches</rdfs:label>
-        <rdfs:label xml:lang="el">Ανθρώπινο Δημιούργημα</rdfs:label>
-        <rdfs:label xml:lang="en">Man-Made Thing</rdfs:label>
-        <rdfs:label xml:lang="fr">Chose fabriquée</rdfs:label>
-        <rdfs:label xml:lang="pt">Coisa Fabricada</rdfs:label>
-        <rdfs:label xml:lang="ru">Рукотворная Вещь</rdfs:label>
         <vitro:descriptionAnnot xml:lang="en">This class comprises discrete, identifiable man-made items that are documented as single units. 
 These items are either intellectual products or man-made physical things, and are characterized by relative stability. They may for instance have a solid physical form, an electronic encoding, or they may be logical concepts or structures.
 </vitro:descriptionAnnot>
+        <rdfs:label xml:lang="en">Man-Made Thing</rdfs:label>
     </owl:Class>
     
 
@@ -111,17 +86,12 @@ These items are either intellectual products or man-made physical things, and ar
     <!-- http://www.cidoc-crm.org/cidoc-crm/E78_Collection -->
 
     <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E78_Collection">
-        <rdfs:label xml:lang="de">Sammlung</rdfs:label>
-        <rdfs:label xml:lang="el">Συλλογή</rdfs:label>
-        <rdfs:label xml:lang="en">Collection</rdfs:label>
-        <rdfs:label xml:lang="fr">Collection</rdfs:label>
-        <rdfs:label xml:lang="pt">Coleção</rdfs:label>
-        <rdfs:label xml:lang="ru">Коллекция</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E24_Physical_Man-Made_Thing"/>
         <vitro:descriptionAnnot xml:lang="en">This class comprises aggregations of instances of E18 Physical Thing that are assembled and maintained (“curated” and “preserved,” in museological terminology) by one or more instances of E39 Actor over time for a specific purpose and audience, and according to a particular collection development plan.  
 Items may be added or removed from an E78 Collection in pursuit of this plan. This class should not be confused with the E39 Actor maintaining the E78 Collection often referred to with the name of the E78 Collection (e.g. “The Wallace Collection decided…”).
 Collective objects in the general sense, like a tomb full of gifts, a folder with stamps or a set of chessmen, should be documented as instances of E19 Physical Object, and not as instances of E78 Collection. This is because they form wholes either because they are physically bound together or because they are kept together for their functionality.
 </vitro:descriptionAnnot>
+        <rdfs:label xml:lang="en">Collection</rdfs:label>
     </owl:Class>
     
 
@@ -129,15 +99,10 @@ Collective objects in the general sense, like a tomb full of gifts, a folder wit
     <!-- http://www.cidoc-crm.org/cidoc-crm/E7_Activity -->
 
     <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E7_Activity">
-        <rdfs:label xml:lang="de">Handlung</rdfs:label>
-        <rdfs:label xml:lang="el">Δράση</rdfs:label>
-        <rdfs:label xml:lang="en">Activity</rdfs:label>
-        <rdfs:label xml:lang="fr">Activité</rdfs:label>
-        <rdfs:label xml:lang="pt">Atividade</rdfs:label>
-        <rdfs:label xml:lang="ru">Деятельность</rdfs:label>
         <vitro:descriptionAnnot xml:lang="en">This class comprises actions intentionally carried out by instances of E39 Actor that result in changes of state in the cultural, social, or physical systems documented. 
 This notion includes complex, composite and long-lasting actions such as the building of a settlement or a war, as well as simple, short-lived actions such as the opening of a door.
 </vitro:descriptionAnnot>
+        <rdfs:label xml:lang="en">Activity</rdfs:label>
     </owl:Class>
     
 
@@ -145,17 +110,16 @@ This notion includes complex, composite and long-lasting actions such as the bui
     <!-- http://www.cidoc-crm.org/cidoc-crm/E87_Curation_Activity -->
 
     <owl:Class rdf:about="http://www.cidoc-crm.org/cidoc-crm/E87_Curation_Activity">
-        <rdfs:label xml:lang="de">Kuratorische Tätigkeit</rdfs:label>
-        <rdfs:label xml:lang="en">Curation Activity</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://www.cidoc-crm.org/cidoc-crm/E7_Activity"/>
         <vitro:descriptionAnnot xml:lang="en">This class comprises the activities that result in the continuity of management and the preservation and evolution of instances of E78 Collection, following an implicit or explicit curation plan. 
 It specializes the notion of activity into the curation of a collection and allows the history of curation to be recorded.
 Items are accumulated and organized following criteria like subject, chronological period, material type, style of art etc. and can be added or removed from an E78 Collection for a specific purpose and/or audience. The initial aggregation of items of a collection is regarded as an instance of E12 Production Event while the activity of evolving, preserving and promoting a collection is regarded as an instance of E87 Curation Activity.
 </vitro:descriptionAnnot>
+        <rdfs:label xml:lang="en">Curation Activity</rdfs:label>
     </owl:Class>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 3.5.1) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.1.3.20151118-2017) https://github.com/owlcs/owlapi -->
 

--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -152,6 +152,12 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/regional_part_of -->
+
+    <ObjectProperty rdf:about="http://purl.obolibrary.org/obo/regional_part_of"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/fma#regional_part_of -->
 
     <ObjectProperty rdf:about="http://purl.obolibrary.org/obo/fma#regional_part_of"/>
@@ -402,6 +408,120 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FMA_52734 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52734"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52735 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52735"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52736 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52736"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52738 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52738"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52739 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52739"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52740 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52740"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52748 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52748"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52788 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52788"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52789 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52789"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52892 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52892"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_52893 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_52893"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_53645 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_53645"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_53646 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_53646"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_53647 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_53647"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_53648 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_53648"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_53649 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_53649"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_53650 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_53650"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_53655 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_53655"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FMA_53656 -->
+
+    <Class rdf:about="http://purl.obolibrary.org/obo/FMA_53656"/>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/IAO_0000030 -->
 
     <Class rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
@@ -566,6 +686,289 @@ A scalar measurement datum, specifying the portion of a bone that is present for
                 <hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</hasValue>
             </Restriction>
         </rdfs:subClassOf>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireEthmoid -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireEthmoid">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52740"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire ethmoid</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireFrontalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireFrontalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52734"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire frontal bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireLeftLacrimalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireLeftLacrimalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53646"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire left lacrimal bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireLeftMaxilla -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireLeftMaxilla">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53650"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire left maxilla</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireLeftNasalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireLeftNasalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53648"/>
+            </Restriction>
+        </rdfs:subClassOf>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireLeftPalatineBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireLeftPalatineBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53656"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire left palatine bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireLeftParietalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireLeftParietalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52789"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire left parietal bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireLeftTemporalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireLeftTemporalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52739"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire left temporal bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireLeftZygomaticBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireLeftZygomaticBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52893"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire left zygomatic bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireMandible -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireMandible">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52748"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire mandible</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireOccipitalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireOccipitalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52735"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire occipital bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireRightLacrimalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireRightLacrimalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53645"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire right lacrimal bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireRightMaxilla -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireRightMaxilla">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53649"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire right maxilla</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireRightNasalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireRightNasalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53647"/>
+            </Restriction>
+        </rdfs:subClassOf>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireRightPalatineBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireRightPalatineBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53655"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire right palatine bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireRightParietalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireRightParietalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52788"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire right parietal bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireRightTemporalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireRightTemporalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52738"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire right temporal bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireRightZygomaticBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireRightZygomaticBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52892"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire right zygomatic bone</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#EntireSphenoidBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#EntireSphenoidBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/regional_part_of"/>
+                <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_52736"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire sphenoid bone</rdfs:label>
     </Class>
     
 

--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -19,6 +19,9 @@
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:statistics="http://purl.org/net/OCRe/statistics.owl#">
     <Ontology rdf:about="http://w3id.org/rdfbones/core">
+        <imports rdf:resource="http://vivoweb.org/ontology/core"/>
+        <imports rdf:resource="http://purl.obolibrary.org/obo/"/>
+        <imports rdf:resource="http://purl.obolibrary.org/obo/RDFBones-fma.owl"/>
         <rdfs:label xml:lang="en-us">RDF Bones</rdfs:label>
         <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">rdfbones</vitro:ontologyPrefixAnnot>
     </Ontology>
@@ -1221,6 +1224,199 @@ A scalar measurement datum, specifying the portion of a bone that is present for
         <obo:IAO_0000112 xml:lang="en">The skeletal inventory representing the skeletal material listed in the collection catalogue of the Alexander Ecker Collection. The catalogue serves as the collection&apos;s primary registry.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">A type of skeletal inventory that is used for entering data into the system. It is referenced by a primary registry.</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Primary skeletal inventory</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#PrimarySkeletalInventoryFreshBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#PrimarySkeletalInventoryFreshBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#PrimarySkeletalInventory"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StaesEntireLeftParietalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireFrontalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftMaxilla"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftNasalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftTemporalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireMandible"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireOccipitalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireRightMaxilla"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireRightParietalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesLeftZygomaticBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightNasalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightTemporalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightZygomaticBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesSphenoidBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StaesEntireLeftParietalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireFrontalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftMaxilla"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftNasalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftTemporalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireMandible"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireOccipitalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireRightMaxilla"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireRightParietalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesLeftZygomaticBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightNasalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightTemporalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightZygomaticBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
+                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
+                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesSphenoidBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <obo:IAO_0000112 xml:lang="en">A bone inventory created in the investigation of a recent forensic case.</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">A primary skeletal inventory recording fresh bone still containing organic matter, as opposed to dry bone where only the mineralised component is present. Measurement values refer to Subclasses of obo:FMA_5018 (&apos;Bone organ&apos;).</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">Primary skeletal inventory for fresh bone material</rdfs:label>
     </Class>
     
 

--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -619,23 +619,26 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     
 
 
+    <!-- http://w3id.org/rdfbones/core#Completeness2StaesEntireLeftParietalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StaesEntireLeftParietalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireLeftParietalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire left parietal bone in two states</rdfs:label>
+    </Class>
+    
+
+
     <!-- http://w3id.org/rdfbones/core#Completeness2State -->
 
     <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2State">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000938"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#CompletenessDatum"/>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
-                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
-                <cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</cardinality>
-            </Restriction>
-        </rdfs:subClassOf>
         <obo:IAO_0000115 xml:lang="en">Categorical measurement datum, expressing the completeness of skeletal elements as either &apos;complete&apos; or &apos;partly present&apos;. It is not designed to express the absence of skeletal elements (e.g. with inventories of skeletons).</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Completeness in two states</rdfs:label>
     </Class>
@@ -648,6 +651,201 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000963"/>
         <obo:IAO_0000115 xml:lang="en">Labels that can be used for the categorical measurement datum &apos;completeness in two states&apos;.</obo:IAO_0000115>
         <rdfs:label xml:lang="en">Label for completeness in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireFrontalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireFrontalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireFrontalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire frontal bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftMaxilla -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftMaxilla">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireLeftMaxilla"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire left maxilla in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftNasalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftNasalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireLeftNasalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire left nasal bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftTemporalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftTemporalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireLeftTemporalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire left temporal bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireMandible -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireMandible">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireMandible"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire mandible in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireOccipitalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireOccipitalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireOccipitalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire occipital bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireRightMaxilla -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireRightMaxilla">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireRightMaxilla"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire right maxilla in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireRightParietalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireRightParietalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireRightParietalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire right parietal bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesLeftZygomaticBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesLeftZygomaticBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireLeftZygomaticBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire left zygomatic bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesRightNasalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesRightNasalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireRightNasalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire right nasal bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesRightTemporalBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesRightTemporalBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireRightTemporalBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire right temporal bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesRightZygomaticBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesRightZygomaticBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireRightZygomaticBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire right zygomatic bone in two states</rdfs:label>
+    </Class>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesSphenoidBone -->
+
+    <Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesSphenoidBone">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2State"/>
+        <rdfs:subClassOf>
+            <Restriction>
+                <onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireSphenoidBone"/>
+            </Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of the entire sphenoid bone in two states</rdfs:label>
     </Class>
     
 
@@ -760,6 +958,7 @@ A scalar measurement datum, specifying the portion of a bone that is present for
                 <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53648"/>
             </Restriction>
         </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire left nasal bone</rdfs:label>
     </Class>
     
 
@@ -894,6 +1093,7 @@ A scalar measurement datum, specifying the portion of a bone that is present for
                 <allValuesFrom rdf:resource="http://purl.obolibrary.org/obo/FMA_53647"/>
             </Restriction>
         </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Entire right nasal bone</rdfs:label>
     </Class>
     
 

--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -19,9 +19,6 @@
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:statistics="http://purl.org/net/OCRe/statistics.owl#">
     <Ontology rdf:about="http://w3id.org/rdfbones/core">
-        <imports rdf:resource="http://vivoweb.org/ontology/core"/>
-        <imports rdf:resource="http://purl.obolibrary.org/obo/"/>
-        <imports rdf:resource="http://purl.obolibrary.org/obo/RDFBones-fma.owl"/>
         <rdfs:label xml:lang="en-us">RDF Bones</rdfs:label>
         <vitro:ontologyPrefixAnnot rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">rdfbones</vitro:ontologyPrefixAnnot>
     </Ontology>
@@ -1314,104 +1311,6 @@ A scalar measurement datum, specifying the portion of a bone that is present for
             <Restriction>
                 <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
                 <someValuesFrom rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesSphenoidBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StaesEntireLeftParietalBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireFrontalBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftMaxilla"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftNasalBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireLeftTemporalBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireMandible"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireOccipitalBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireRightMaxilla"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireRightParietalBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesLeftZygomaticBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightNasalBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightTemporalBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesRightZygomaticBone"/>
-            </Restriction>
-        </rdfs:subClassOf>
-        <rdfs:subClassOf>
-            <Restriction>
-                <onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                <qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</qualifiedCardinality>
-                <onClass rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesSphenoidBone"/>
             </Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000112 xml:lang="en">A bone inventory created in the investigation of a recent forensic case.</obo:IAO_0000112>


### PR DESCRIPTION
This implements all subclasses of rdfbones:CompletenessDatum and rdfbones:BoneSegment that are needed to build a primary skeletal inventory of the type rdfbones:PrimarySkeletalInventoryFreshBone.

@kdaveed The subclass of rdfbones:PrimarySkeletalInventory had to be created to distinguish use cases where fresh bone or dry bone (from archaeological excavations) are described. They need to refer to different classes in the FMA. For you this does not make a great difference, just use rdfbones:PrimarySkeletalInventoryFreshBone instead of rdfbones:PrimarySkeletalInventory.

@kdaveed VIVO does not respect the restrictions on obo:BFO_0000051 ('has part'), so it is impossible to use the property with the standard VIVO GUI. Faux properties would be needed to amend this. But I do not know if they are still needed for your plans with the GUI? Same goes for the bone sections of type rdfbones:EntireBone.