### PR TITLE
Hierarchy completeness bony parts of bone organs

### DIFF
--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -4707,6 +4707,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfBigToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfBigToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfBigToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -4737,6 +4738,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFourthToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -4752,6 +4754,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfIndexFinger">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -4917,6 +4920,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleFinger">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -4932,6 +4936,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -4947,6 +4952,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfMiddleFinger">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -5112,6 +5118,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRingFinger">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -5127,6 +5134,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfSecondToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -5142,6 +5150,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThirdToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -5157,6 +5166,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThumb -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThumb">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThumb"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -6717,6 +6727,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFourthToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -6732,6 +6743,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfIndexFinger">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -6867,6 +6879,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleFinger">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -6882,6 +6895,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -6897,6 +6911,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfMiddleFinger">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -7032,6 +7047,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRingFinger">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFinger"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -7047,6 +7063,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfSecondToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -7062,6 +7079,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfThirdToe">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfToe"/>
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -7453,6 +7471,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfBigToe">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfBigToe"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7483,6 +7502,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFourthToe">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFourthToe"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7498,6 +7518,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfIndexFinger">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfIndexFinger"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7663,6 +7684,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleFinger">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleFinger"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7678,6 +7700,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleToe">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleToe"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7693,6 +7716,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfMiddleFinger">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfMiddleFinger"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7858,6 +7882,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRingFinger">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfRingFinger"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7873,6 +7898,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfSecondToe">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfSecondToe"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7888,6 +7914,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThirdToe">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThirdToe"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7903,6 +7930,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThumb">
         <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThumb"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>

--- a/RDFBones.owl
+++ b/RDFBones.owl
@@ -4497,7 +4497,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfAtlas -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfAtlas">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4512,7 +4512,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfAtypicalRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfAtypicalRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrueRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4527,7 +4527,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfAxis -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfAxis">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4539,10 +4539,25 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     
 
 
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireBonyPartOfBoneOrgan"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of entire bony part of bone organ in two states</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCalcaneus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCalcaneus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4557,7 +4572,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCapitate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCapitate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4572,7 +4587,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4587,7 +4602,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4602,7 +4617,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfClavicle -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfClavicle">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4617,7 +4632,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCoccygealVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCoccygealVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4632,7 +4647,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCoccyx -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCoccyx">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4647,7 +4662,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuboidBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuboidBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4662,7 +4677,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4677,7 +4692,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalCarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalCarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4692,7 +4707,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfBigToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfBigToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfBigToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4707,7 +4722,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4722,7 +4737,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4737,7 +4752,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4752,7 +4767,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftBigToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftBigToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfBigToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4767,7 +4782,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4782,7 +4797,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4797,7 +4812,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4812,7 +4827,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4827,7 +4842,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4842,7 +4857,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4857,7 +4872,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4872,7 +4887,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4887,7 +4902,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftThumb -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLeftThumb">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThumb"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4902,7 +4917,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4917,7 +4932,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4932,7 +4947,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4947,7 +4962,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightBigToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightBigToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfBigToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4962,7 +4977,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4977,7 +4992,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -4992,7 +5007,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5007,7 +5022,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5022,7 +5037,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5037,7 +5052,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5052,7 +5067,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5067,7 +5082,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5082,7 +5097,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightThumb -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRightThumb">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThumb"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5097,7 +5112,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5112,7 +5127,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5127,7 +5142,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5142,7 +5157,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThumb -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfThumb">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThumb"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5157,7 +5172,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalPhalanxOfToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5172,7 +5187,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEighthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEighthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5187,7 +5202,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEighthThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEighthThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5202,7 +5217,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEleventhRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEleventhRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5217,7 +5232,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEleventhThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEleventhThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5232,7 +5247,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEthmoid -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEthmoid">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5247,7 +5262,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFalseRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFalseRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5262,7 +5277,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFemur -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFemur">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5277,7 +5292,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFibula -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFibula">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5292,7 +5307,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthCervicalVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthCervicalVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5307,7 +5322,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthLumbarVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthLumbarVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLumbarVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5322,7 +5337,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5337,7 +5352,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5352,7 +5367,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5367,7 +5382,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthSacralVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthSacralVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacralVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5382,7 +5397,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5397,7 +5412,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstCoccygealVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstCoccygealVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCoccygealVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5412,7 +5427,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstLumbarVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstLumbarVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLumbarVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5427,7 +5442,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5442,7 +5457,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5457,7 +5472,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5472,7 +5487,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstSacralVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstSacralVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacralVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5487,7 +5502,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5502,7 +5517,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFloatingRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFloatingRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFalseRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5517,7 +5532,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthCervicalVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthCervicalVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5532,7 +5547,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthCoccygealVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthCoccygealVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCoccygealVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5547,7 +5562,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthLumbarVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthLumbarVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLumbarVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5562,7 +5577,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5577,7 +5592,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5592,7 +5607,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5607,7 +5622,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthSacralVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthSacralVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacralVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5622,7 +5637,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5637,7 +5652,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFrontalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFrontalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5652,7 +5667,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHamate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHamate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5667,7 +5682,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHipBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHipBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5682,7 +5697,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHumerus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHumerus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5697,7 +5712,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHyoidBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHyoidBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5712,7 +5727,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfInferiorNasalConcha -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfInferiorNasalConcha">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5727,7 +5742,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfIntermediateCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfIntermediateCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5742,7 +5757,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLacrimalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLacrimalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5757,7 +5772,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLateralCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLateralCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5772,7 +5787,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftCalcaneus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftCalcaneus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCalcaneus"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5787,7 +5802,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftCapitate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftCapitate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCapitate"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5802,7 +5817,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftClavicle -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftClavicle">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfClavicle"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5817,7 +5832,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftCuboidBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftCuboidBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuboidBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5832,7 +5847,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftEighthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftEighthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEighthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5847,7 +5862,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftEleventhRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftEleventhRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEleventhRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5862,7 +5877,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFemur -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFemur">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFemur"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5877,7 +5892,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFibula -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFibula">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFibula"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5892,7 +5907,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFifthMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFifthMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5907,7 +5922,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFifthMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFifthMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5919,10 +5934,25 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     
 
 
+    <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFifthRib -->
+
+    <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFifthRib">
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthRib"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+                <owl:allValuesFrom rdf:resource="http://w3id.org/rdfbones/core#EntireBonyPartOfLeftFifthRib"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">Completeness of entire bony part of left fifth rib in two states</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFirstMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFirstMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5937,7 +5967,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFirstMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFirstMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5952,7 +5982,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFirstRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFirstRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5967,7 +5997,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFourthMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFourthMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5982,7 +6012,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFourthMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFourthMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -5997,7 +6027,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFourthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftFourthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6012,7 +6042,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftHamate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftHamate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHamate"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6027,7 +6057,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftHipBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftHipBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHipBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6042,7 +6072,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftHumerus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftHumerus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHumerus"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6057,7 +6087,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftInferiorNasalConcha -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftInferiorNasalConcha">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfInferiorNasalConcha"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6072,7 +6102,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftIntermediateCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftIntermediateCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfIntermediateCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6087,7 +6117,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftLacrimalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftLacrimalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLacrimalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6102,7 +6132,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftLateralCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftLateralCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLateralCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6117,7 +6147,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftLunate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftLunate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLunate"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6132,7 +6162,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftMaxilla -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftMaxilla">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMaxilla"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6147,7 +6177,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftMedialCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftMedialCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMedialCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6162,7 +6192,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftNasalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftNasalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNasalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6177,7 +6207,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftNinthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftNinthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNinthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6192,7 +6222,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftPalatineBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftPalatineBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPalatineBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6207,7 +6237,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftParietalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftParietalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfParietalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6222,7 +6252,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftPatella -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftPatella">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPatella"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6237,7 +6267,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftPisiform -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftPisiform">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPisiform"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6252,7 +6282,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftRadius -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftRadius">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRadius"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6267,7 +6297,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftScaphoid -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftScaphoid">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfScaphoid"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6282,7 +6312,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftScapula -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftScapula">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfScapula"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6297,7 +6327,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSecondMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSecondMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6312,7 +6342,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSecondMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSecondMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6327,7 +6357,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSecondRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSecondRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6342,7 +6372,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSeventhRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSeventhRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSeventhRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6357,7 +6387,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSixthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftSixthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSixthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6372,7 +6402,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTalus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTalus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTalus"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6387,7 +6417,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTemporalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTemporalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTemporalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6402,7 +6432,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTenthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTenthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTenthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6417,7 +6447,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftThirdMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftThirdMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6432,7 +6462,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftThirdMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftThirdMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6447,7 +6477,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftThirdRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftThirdRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6462,7 +6492,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTibia -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTibia">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTibia"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6477,7 +6507,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTrapezium -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTrapezium">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrapezium"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6492,7 +6522,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTrapezoid -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTrapezoid">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrapezoid"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6507,7 +6537,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTriquetral -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTriquetral">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTriquetral"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6522,7 +6552,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTwelfthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftTwelfthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTwelfthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6537,7 +6567,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftUlna -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftUlna">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfUlna"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6552,7 +6582,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftZygomaticBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLeftZygomaticBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfZygomaticBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6567,7 +6597,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLumbarVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLumbarVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6582,7 +6612,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLunate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLunate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6597,7 +6627,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMandible -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMandible">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6612,7 +6642,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMaxilla -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMaxilla">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6627,7 +6657,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMedialCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMedialCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6642,7 +6672,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6657,7 +6687,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6672,7 +6702,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6687,7 +6717,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6702,7 +6732,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6717,7 +6747,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6732,7 +6762,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6747,7 +6777,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6762,7 +6792,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6777,7 +6807,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6792,7 +6822,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6807,7 +6837,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6822,7 +6852,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLeftThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6837,7 +6867,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6852,7 +6882,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6867,7 +6897,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6882,7 +6912,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6897,7 +6927,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6912,7 +6942,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6927,7 +6957,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6942,7 +6972,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6957,7 +6987,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6972,7 +7002,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -6987,7 +7017,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRightThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7002,7 +7032,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7017,7 +7047,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7032,7 +7062,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7047,7 +7077,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMiddlePhalanxOfToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7062,7 +7092,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNasalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNasalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7077,7 +7107,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNavicularBoneOfFoot -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNavicularBoneOfFoot">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7092,7 +7122,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNavicularBoneOfLeftFoot -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNavicularBoneOfLeftFoot">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNavicularBoneOfFoot"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7107,7 +7137,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNavicularBoneOfRightFoot -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNavicularBoneOfRightFoot">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNavicularBoneOfFoot"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7122,7 +7152,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNinthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNinthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7137,7 +7167,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNinthThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNinthThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7152,7 +7182,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfOccipitalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfOccipitalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7167,7 +7197,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPalatineBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPalatineBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7182,7 +7212,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfParietalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfParietalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7197,7 +7227,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPatella -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPatella">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7212,7 +7242,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfBigToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfBigToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7227,7 +7257,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7242,7 +7272,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7257,7 +7287,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7272,7 +7302,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7287,7 +7317,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7302,7 +7332,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7317,7 +7347,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7332,7 +7362,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7347,7 +7377,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7362,7 +7392,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThumb -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThumb">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7377,7 +7407,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7392,7 +7422,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPisiform -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPisiform">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7407,7 +7437,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalCarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalCarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7422,7 +7452,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfBigToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfBigToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfBigToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7437,7 +7467,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7452,7 +7482,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7467,7 +7497,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7482,7 +7512,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftBigToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftBigToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfBigToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7497,7 +7527,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7512,7 +7542,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7527,7 +7557,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7542,7 +7572,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7557,7 +7587,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7572,7 +7602,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7587,7 +7617,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7602,7 +7632,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7617,7 +7647,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftThumb -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLeftThumb">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThumb"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7632,7 +7662,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7647,7 +7677,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7662,7 +7692,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7677,7 +7707,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightBigToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightBigToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfBigToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7692,7 +7722,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightFourthToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightFourthToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfFourthToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7707,7 +7737,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightIndexFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightIndexFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfIndexFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7722,7 +7752,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightLittleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightLittleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7737,7 +7767,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightLittleToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightLittleToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfLittleToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7752,7 +7782,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightMiddleFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightMiddleFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfMiddleFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7767,7 +7797,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7782,7 +7812,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7797,7 +7827,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7812,7 +7842,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightThumb -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRightThumb">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThumb"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7827,7 +7857,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRingFinger -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfRingFinger">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfRingFinger"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7842,7 +7872,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfSecondToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfSecondToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfSecondToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7857,7 +7887,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThirdToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThirdToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThirdToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7872,7 +7902,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThumb -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfThumb">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfThumb"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7887,7 +7917,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfToe -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalPhalanxOfToe">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPhalanxOfToe"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7902,7 +7932,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRadius -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRadius">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7917,7 +7947,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7932,7 +7962,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightCalcaneus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightCalcaneus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCalcaneus"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7947,7 +7977,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightCapitate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightCapitate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCapitate"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7962,7 +7992,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightClavicle -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightClavicle">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfClavicle"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7977,7 +8007,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightCuboidBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightCuboidBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCuboidBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -7992,7 +8022,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightEighthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightEighthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEighthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8007,7 +8037,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightEleventhRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightEleventhRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfEleventhRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8022,7 +8052,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFemur -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFemur">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFemur"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8037,7 +8067,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFibula -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFibula">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFibula"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8052,7 +8082,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFifthMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFifthMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8067,7 +8097,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFifthMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFifthMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8082,7 +8112,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFifthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFifthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFifthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8097,7 +8127,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFirstMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFirstMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8112,7 +8142,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFirstMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFirstMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8127,7 +8157,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFirstRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFirstRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFirstRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8142,7 +8172,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFourthMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFourthMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8157,7 +8187,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFourthMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFourthMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8172,7 +8202,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFourthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightFourthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfFourthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8187,7 +8217,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightHamate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightHamate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHamate"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8202,7 +8232,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightHipBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightHipBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHipBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8217,7 +8247,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightHumerus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightHumerus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfHumerus"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8232,7 +8262,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightInferiorNasalConcha -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightInferiorNasalConcha">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfInferiorNasalConcha"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8247,7 +8277,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightIntermediateCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightIntermediateCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfIntermediateCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8262,7 +8292,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightLacrimalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightLacrimalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLacrimalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8277,7 +8307,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightLateralCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightLateralCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLateralCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8292,7 +8322,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightLunate -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightLunate">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLunate"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8307,7 +8337,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightMaxilla -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightMaxilla">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMaxilla"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8322,7 +8352,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightMedialCuneiformBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightMedialCuneiformBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMedialCuneiformBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8337,7 +8367,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightNasalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightNasalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNasalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8352,7 +8382,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightNinthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightNinthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfNinthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8367,7 +8397,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightPalatineBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightPalatineBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPalatineBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8382,7 +8412,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightParietalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightParietalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfParietalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8397,7 +8427,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightPatella -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightPatella">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPatella"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8412,7 +8442,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightPisiform -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightPisiform">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfPisiform"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8427,7 +8457,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightRadius -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightRadius">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRadius"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8442,7 +8472,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightScaphoid -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightScaphoid">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfScaphoid"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8457,7 +8487,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightScapula -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightScapula">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfScapula"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8472,7 +8502,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSecondMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSecondMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8487,7 +8517,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSecondMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSecondMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8502,7 +8532,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSecondRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSecondRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8517,7 +8547,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSeventhRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSeventhRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSeventhRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8532,7 +8562,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSixthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightSixthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSixthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8547,7 +8577,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTalus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTalus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTalus"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8562,7 +8592,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTemporalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTemporalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTemporalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8577,7 +8607,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTenthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTenthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTenthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8592,7 +8622,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightThirdMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightThirdMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8607,7 +8637,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightThirdMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightThirdMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8622,7 +8652,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightThirdRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightThirdRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8637,7 +8667,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTibia -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTibia">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTibia"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8652,7 +8682,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTrapezium -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTrapezium">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrapezium"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8667,7 +8697,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTrapezoid -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTrapezoid">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrapezoid"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8682,7 +8712,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTriquetral -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTriquetral">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTriquetral"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8697,7 +8727,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTwelfthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightTwelfthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTwelfthRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8712,7 +8742,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightUlna -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightUlna">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfUlna"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8727,7 +8757,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightZygomaticBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRightZygomaticBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfZygomaticBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8742,7 +8772,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacralVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacralVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8757,7 +8787,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacrum -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacrum">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8772,7 +8802,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfScaphoid -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfScaphoid">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8787,7 +8817,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfScapula -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfScapula">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8802,7 +8832,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondCoccygealVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondCoccygealVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCoccygealVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8817,7 +8847,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondLumbarVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondLumbarVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLumbarVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8832,7 +8862,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8847,7 +8877,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8862,7 +8892,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8877,7 +8907,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondSacralVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondSacralVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacralVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8892,7 +8922,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSecondThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8907,7 +8937,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSeventhCervicalVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSeventhCervicalVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8922,7 +8952,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSeventhRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSeventhRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8937,7 +8967,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSeventhThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSeventhThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8952,7 +8982,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSixthCervicalVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSixthCervicalVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8967,7 +8997,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSixthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSixthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8982,7 +9012,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSixthThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSixthThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -8997,7 +9027,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSphenoidBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSphenoidBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9012,7 +9042,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSternum -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSternum">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9027,7 +9057,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTalus -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTalus">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9042,7 +9072,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9057,7 +9087,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTemporalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTemporalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9072,7 +9102,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTenthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTenthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9087,7 +9117,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTenthThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTenthThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9102,7 +9132,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdCervicalVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdCervicalVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCervicalVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9117,7 +9147,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdCoccygealVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdCoccygealVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfCoccygealVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9132,7 +9162,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdLumbarVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdLumbarVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfLumbarVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9147,7 +9177,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdMetacarpalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdMetacarpalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetacarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9162,7 +9192,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdMetatarsalBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdMetatarsalBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfMetatarsalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9177,7 +9207,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9192,7 +9222,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdSacralVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdSacralVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfSacralVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9207,7 +9237,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThirdThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9222,7 +9252,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9237,7 +9267,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTibia -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTibia">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9252,7 +9282,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrapezium -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrapezium">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9267,7 +9297,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrapezoid -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrapezoid">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfDistalCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9282,7 +9312,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTriquetral -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTriquetral">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfProximalCarpalBone"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9297,7 +9327,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrueRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrueRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9312,7 +9342,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTwelfthRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTwelfthRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9327,7 +9357,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTwelfthThoracicVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTwelfthThoracicVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfThoracicVertebra"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9342,7 +9372,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTypicalRib -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTypicalRib">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfTrueRib"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9357,7 +9387,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfUlna -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfUlna">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9372,7 +9402,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVertebra -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVertebra">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9387,7 +9417,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVomer -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfVomer">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
@@ -9402,7 +9432,7 @@ The frontal part of the right parietal bone.</obo:IAO_0000112>
     <!-- http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfZygomaticBone -->
 
     <owl:Class rdf:about="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfZygomaticBone">
-        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2States"/>
+        <rdfs:subClassOf rdf:resource="http://w3id.org/rdfbones/core#Completeness2StatesEntireBonyPartOfBoneOrgan"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>


### PR DESCRIPTION
Data on completeness in two states of bony parts of bone organs are arranged in a subclass hierarchy under the new class rdfbones:Completeness2StatesBonyPartOfBoneOrgan. Also, data on phalanges are subclass both of data on types of fingers or toes and of types of phalanges (proximal, middle, distal).

Fixes #104.