### PR TITLE
Default Labels and Values

### DIFF
--- a/RDFBones-main.owl
+++ b/RDFBones-main.owl
@@ -346,40 +346,40 @@
     
 
 
-    <!-- http://w3id.org/rdfbones/core/hasDefaultValue -->
+    <!-- http://w3id.org/rdfbones/core/hasDefaultLabel -->
 
-    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core/hasDefaultValue">
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core/hasDefaultLabel">
       <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/> <!-- 'measurement datum' -->
-      <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/> <!-- 'information content entity -->
-      <obo:IAO_0000115 xml:lang="en">An object property that assigns a default value to a measurement datum. Default values can be used to automatically assign a value in case that no data is provided or inthat a certain scenario is given.</obo:IAO_0000115>
-        <obo:IAO_0000116 xml:lang="en">This object property can be used in class restrictions to define default values for a certain measurement datum class.</obo:IAO_0000116>
-        <obo:IAO_0000116 xml:lang="en">The use case for which the object property was introduced is to define a categorical label that is to be attached to a categorical measurement datum in a specific situation (e.g. if a measurement is impossible due to absence of requiered material). Domain and range definitions are broader in order to cover other use cases that might arise in the future.</obo:IAO_0000116>
+      <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000009"/> <!-- 'datum label' -->
+      <obo:IAO_0000115 xml:lang="en">An object property that assigns a default value in the form of a defined datum label to a measurement datum. Default values can be used to automatically assign a value in case that no data is provided or in that a certain scenario is given.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">This object property can be used in class restrictions to define default labels for a certain measurement datum class.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">The use case for which the object property was introduced is to define a categorical label that is to be attached to a categorical measurement datum in a specific situation (e.g. if a measurement is impossible due to absence of requiered material). The domain definition is broader in order to cover other use cases that might arise in the future.</obo:IAO_0000116>
         <obo:IAO_0000116 xml:lang="en">Besides its informative value, class restrictions using this object property can be evaluated by software applications to automatically assign values to multiple measurement data if a user defines a certain scenario (e.g. 'no assessment conducted' or 'no material present').</obo:IAO_0000116>
         <obo:IAO_0000116 xml:lang="en">Subclasses of this object property can be defined for specific scenarios (e.g. 'no evidence' or 'not assessed')</obo:IAO_0000116>
         <obo:IAO_0000117>Felix Engel</obo:IAO_0000117>
-      <rdfs:label xml:lang="en">has default value</rdfs:label>
+      <rdfs:label xml:lang="en">has default label</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://w3id.org/rdfbones/core/hasMissingMaterialValue -->
+    <!-- http://w3id.org/rdfbones/core/hasMissingMaterialLabel -->
 
-    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core/hasMissingMaterialValue">
-      <rdfs:subPropertyOf rdf:resource="http://w3id.org/rdfbones/core/hasDefaultValue"/>
-      <obo:IAO_0000115 xml:lang="en">An object property that assigns a default value for a specific measurement value to take on in case that the measurement cannot be carried out due to the fact that the material to be measured is not present or incomplete.</obo:IAO_0000115>
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core/hasMissingMaterialLabel">
+      <rdfs:subPropertyOf rdf:resource="http://w3id.org/rdfbones/core/hasDefaultLabel"/>
+      <obo:IAO_0000115 xml:lang="en">An object property that assigns a default value in the form of a defined datum label for a specific measurement datum to take on in case that the measurement cannot be carried out due to the fact that the material to be measured is not present or incomplete.</obo:IAO_0000115>
         <obo:IAO_0000117>Felix Engel</obo:IAO_0000117>
-      <rdfs:label xml:lang="en">has missing material value</rdfs:label>
+      <rdfs:label xml:lang="en">has missing material label</rdfs:label>
     </owl:ObjectProperty>
     
 
 
-    <!-- http://w3id.org/rdfbones/core/hasNotAvailableValue -->
+    <!-- http://w3id.org/rdfbones/core/hasNotAvailableLabel -->
 
-    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core/hasNotAvailableValue">
-      <rdfs:subPropertyOf rdf:resource="http://w3id.org/rdfbones/core/hasDefaultValue"/>
-      <obo:IAO_0000115 xml:lang="en">An object property that assigns a default value for a specific measurement value to take on in case that the measurement cannot be carried out.</obo:IAO_0000115>
+    <owl:ObjectProperty rdf:about="http://w3id.org/rdfbones/core/hasNotAvailableLabel">
+      <rdfs:subPropertyOf rdf:resource="http://w3id.org/rdfbones/core/hasDefaultLabel"/>
+      <obo:IAO_0000115 xml:lang="en">An object property that assigns a default value in the form of a defined datum label for a specific measurement value to take on in case that the measurement cannot be carried out.</obo:IAO_0000115>
         <obo:IAO_0000117>Felix Engel</obo:IAO_0000117>
-      <rdfs:label xml:lang="en">has not available value</rdfs:label>
+      <rdfs:label xml:lang="en">has not available label</rdfs:label>
     </owl:ObjectProperty>
 
 
@@ -466,6 +466,43 @@
         <obo:IAO_0000112 xml:lang="en">The portion of the left parietal bone that a bone organ segment, defined as &apos;frontal part of the left parietal bone&apos;, represents.</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">Renders the portion (0 &lt; bone portion &lt;= 1) of a bone organ that a certain entity occupies.</obo:IAO_0000115>
         <rdfs:label xml:lang="en">bone portion</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#hasDefaultValue -->
+
+    <owl:DatatypeProperty rdf:about="http://w3id.org/rdfbones/core#hasDefaultValue">
+      <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/> <!-- 'measurement datum' -->
+      <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+      <obo:IAO_0000115 xml:lang="en">A data property that assigns a default value to a measurement datum. Default values can be used to automatically assign a value in case that no data is provided or in that a certain scenario is given.</obo:IAO_0000115>
+      <obo:IAO_0000116 xml:lang="en">This data property can be used in class restrictions to define default labels for a certain measurement datum class.</obo:IAO_0000116>
+      <obo:IAO_0000116 xml:lang="en">Besides its informative value, class restrictions using this object property can be evaluated by software applications to automatically assign values to multiple measurement data if a user defines a certain scenario (e.g. 'no assessment conducted' or 'no material present').</obo:IAO_0000116>
+      <obo:IAO_0000116 xml:lang="en">Subclasses of this data property can be defined for specific scenarios (e.g. 'no evidence' or 'not assessed')</obo:IAO_0000116>
+      <obo:IAO_0000117>Felix Engel</obo:IAO_0000117>
+      <rdfs:label xml:lang="en">has default value</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#hasMissingMaterialValue -->
+
+    <owl:DatatypeProperty rdf:about="http://w3id.org/rdfbones/core#hasMissingMaterialValue">
+      <rdfs:subPropertyOf rdf:resource="http://w3id.org/rdfbones/core#hasDefaultValue"/>
+      <obo:IAO_0000115 xml:lang="en">A data property that assigns a default value for a measurement datum to take on in case that the measurement cannot be carried out due to the fact that the material to be measured is not present or incomplete.</obo:IAO_0000115>
+      <obo:IAO_0000117>Felix Engel</obo:IAO_0000117>
+      <rdfs:label xml:lang="en">has missing material value</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- http://w3id.org/rdfbones/core#hasNotAvailableValue -->
+
+    <owl:DatatypeProperty rdf:about="http://w3id.org/rdfbones/core#hasNotAvailableValue">
+      <rdfs:subPropertyOf rdf:resource="http://w3id.org/rdfbones/core#hasDefaultValue"/>
+      <obo:IAO_0000115 xml:lang="en">A data property that assigns a default value for a measurement datum to take on in case that the measurement cannot be carried out.</obo:IAO_0000115>
+      <obo:IAO_0000117>Felix Engel</obo:IAO_0000117>
+      <rdfs:label xml:lang="en">has not available value</rdfs:label>
     </owl:DatatypeProperty>
     
 


### PR DESCRIPTION
Following discussion at the RDFBones/AnthroGraph meeting on 29 November 2022, this pull request implements a distinction between default labels for categorical measurement data (object property 'has default label') and default values for scalar measurement data (data property 'has default value').